### PR TITLE
replaces curly apostrophes with regular ones to fix audio stumbling

### DIFF
--- a/js/get_selection.js
+++ b/js/get_selection.js
@@ -15,4 +15,4 @@
  *  browser ever build :) 
  * -----------------------------------------------------------------------------
 */
-chrome.extension.sendRequest({"text": window.getSelection().toString()});
+chrome.extension.sendRequest({"text": window.getSelection().toString().replace(/[\u2019]/g, "'")});


### PR DESCRIPTION
When the text-to-speech engine encounters a word with a curly apostrophe (`’`) as opposed to a regular one (`'`), it treats it like a full stop, pauses, and then reads the second half of the word awkwardly. By simply replacing apostrophes, we can fix this